### PR TITLE
Fix break window range

### DIFF
--- a/app.py
+++ b/app.py
@@ -89,7 +89,8 @@ def generate_patterns(
     for combo in day_combos(ft_days):
         for start in range(1, S - ft_daily_hours + 2):
             for brk in range(
-                start + break_window_start, start + break_window_end - break_length + 2
+                start + break_window_start,
+                start + break_window_end - break_length + 1,
             ):
                 coverage = []
                 for d in combo:


### PR DESCRIPTION
## Summary
- ensure break windows respect the end slot in `generate_patterns`

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_687947572aa483278d4d4af7a58c896b