### PR TITLE
Clarify break window offsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,11 @@ Once the file is uploaded you can experiment with the predefined shift
 templates or provide your own daily hours. The application generates all
 possible patterns, solves the coverage model and reports the resulting
 schedule and coverage percentage.
+
+### Break window configuration
+
+The break window is defined by two offsets from the start of the shift:
+
+* **Break Window Start** – earliest slot where a break may begin.
+* **Break Window End** – last slot where a break may begin. The window must
+  be wide enough to fit the chosen break length.


### PR DESCRIPTION
## Summary
- document how break_window_start and break_window_end are measured
- validate break window values in `generate_patterns` and in the UI
- update UI labels to clarify offsets
- mention break window configuration in the README

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68797cefa3588327b074a3ae9de83467