### PR TITLE
Handle uncovered slots

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ part-time patterns so that demand coverage is maximized with the minimum number 
    streamlit run app.py
    ```
 
+## Usage
+
+When solving a schedule the app will alert you if no generated pattern
+covers a particular day and slot combination. Adjust your shift templates
+or break settings if this occurs.
+
 ## Demand data
 
 Upload the staffing demand as an Excel file. The spreadsheet must contain the


### PR DESCRIPTION
## Summary
- detect when no pattern covers a day/slot in `solve_schedule`
- surface the error from `solve_schedule` in the Streamlit app
- document this validation behaviour

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6879927402c48327b9cfb61f89fa6051